### PR TITLE
Add patch permissions to codebuild

### DIFF
--- a/kubernetes/users/discourse-dev-rbac.yaml
+++ b/kubernetes/users/discourse-dev-rbac.yaml
@@ -51,6 +51,7 @@ rules:
   verbs:
   - get
   - create
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/kubernetes/users/discourse-prod-rbac.yaml
+++ b/kubernetes/users/discourse-prod-rbac.yaml
@@ -45,6 +45,7 @@ rules:
   verbs:
   - get
   - create
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/kubernetes/users/discourse-staging-rbac.yaml
+++ b/kubernetes/users/discourse-staging-rbac.yaml
@@ -45,6 +45,7 @@ rules:
   verbs:
   - get
   - create
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
This permissions are needed when modifying the current configuration of the HPA