### PR TITLE
Enable custom domain for SES

### DIFF
--- a/terraform/deployment.tf
+++ b/terraform/deployment.tf
@@ -100,6 +100,11 @@ resource "aws_codebuild_project" "discourse" {
       "name"  = "CODE_REVISION"
       "value" = "tests-passed"
     }
+
+    environment_variable {
+      "name"  = "SES_DOMAIN"
+      "value" = "${var.ses-domain}"
+    }
   }
 
   source {


### PR DESCRIPTION
During the transition period when discourse.m.o is used in the old infra, we need to add the possibility to use a custom domain for SES. So like this we can expose the pre-prod site in discourse-prod.itsre-apps.mozit.cloud but having managing email for discourse.mozilla.org