### PR TITLE
Use this infrastruture for production

### DIFF
--- a/terraform/deployment.tf
+++ b/terraform/deployment.tf
@@ -63,7 +63,7 @@ resource "aws_codebuild_project" "discourse" {
 
     environment_variable {
       "name"  = "CDN_URL"
-      "value" = "https://cdn.${var.discourse-url}"
+      "value" = "https://cdn.${var.discourse-cdn-zone}"
     }
 
     environment_variable {

--- a/terraform/dev.tfvars
+++ b/terraform/dev.tfvars
@@ -3,6 +3,7 @@
 #############
 "discourse-url" = "discourse-dev.itsre-apps.mozit.cloud"
 "discourse-elb" = "ab30fe62db90e11e99aba06db27de6a9"
+"discourse-cdn-zone" = "discourse-dev.itsre-apps.mozit.cloud"
 
 #########
 # Redis #

--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -1,14 +1,15 @@
 #############
 # Discourse #
 #############
-"discourse-url" = "discourse-prod.itsre-apps.mozit.cloud"
+"discourse-url" = "discourse.mozilla.org"
 "discourse-elb" = "a4973975cda0c11e9807a021c7053ca0"
+"discourse-cdn-zone" = "discourse-prod.itsre-apps.mozit.cloud"
 
 
 #########
 # Redis #
 #########
-"redis-instance" = "cache.t2.medium"
+"redis-instance" = "cache.t2.small"
 "redis-num-nodes" = 1
 "redis-version" = "5.0.4"
 
@@ -16,7 +17,7 @@
 ##########
 #  PSQL  #
 ##########
-"psql-instance" = "db.m5.large"
+"psql-instance" = "db.t3.small"
 "psql-version" = "10"
 "psql-storage-allocated" = 30
 "psql-storage-max"  = 100
@@ -32,5 +33,3 @@
 #     Email     #
 #################
 "ses-domain" = "discourse.mozilla.org"
-#"ses-domain" = "discourse-prod.itsre-apps.mozit.cloud"
-  

--- a/terraform/staging.tfvars
+++ b/terraform/staging.tfvars
@@ -3,6 +3,7 @@
 #############
 "discourse-url" = "discourse-staging.itsre-apps.mozit.cloud"
 "discourse-elb" = "ac23bf095c8af11e99ca602ac9836d17"
+"discourse-cdn-zone" = "discourse-staging.itsre-apps.mozit.cloud"
 
 
 #########

--- a/terraform/users.tf
+++ b/terraform/users.tf
@@ -4,8 +4,8 @@
 
 # Alberto
 resource "aws_iam_user" "adelbarrio" {
-  name = "adelbarrio"
-	count = "${terraform.workspace == "prod" ? "1" : "0"}"
+  name  = "adelbarrio"
+  count = "${terraform.workspace == "prod" ? "1" : "0"}"
 
   # Not supported by EKS:
   #path = "/discourse/"
@@ -13,9 +13,9 @@ resource "aws_iam_user" "adelbarrio" {
 }
 
 resource "aws_iam_user_policy" "adelbarrio_mfa" {
-  name = "allow-${aws_iam_user.adelbarrio.name}-self-manage-mfa"
-  user = "${aws_iam_user.adelbarrio.name}"
-	count = "${terraform.workspace == "prod" ? "1" : "0"}"
+  name  = "allow-${aws_iam_user.adelbarrio.name}-self-manage-mfa"
+  user  = "${aws_iam_user.adelbarrio.name}"
+  count = "${terraform.workspace == "prod" ? "1" : "0"}"
 
   policy = <<EOF
 {
@@ -80,7 +80,7 @@ resource "aws_iam_user_login_profile" "adelbarrio" {
   user                    = "${aws_iam_user.adelbarrio.name}"
   pgp_key                 = "keybase:adelbarrio"
   password_reset_required = false
-	count = "${terraform.workspace == "prod" ? "1" : "0"}"
+  count                   = "${terraform.workspace == "prod" ? "1" : "0"}"
 
   lifecycle {
     ignore_changes = ["password_length", "password_reset_required", "pgp_key"]
@@ -89,8 +89,8 @@ resource "aws_iam_user_login_profile" "adelbarrio" {
 
 # Leo
 resource "aws_iam_user" "lmcardle" {
-  name = "lmcardle"
-	count = "${terraform.workspace == "prod" ? "1" : "0"}"
+  name  = "lmcardle"
+  count = "${terraform.workspace == "prod" ? "1" : "0"}"
 
   # Not supported by EKS:
   #path = "/discourse/"
@@ -98,9 +98,9 @@ resource "aws_iam_user" "lmcardle" {
 }
 
 resource "aws_iam_user_policy" "lmcardle_mfa" {
-  name = "allow-${aws_iam_user.lmcardle.name}-self-manage-mfa"
-  user = "${aws_iam_user.lmcardle.name}"
-	count = "${terraform.workspace == "prod" ? "1" : "0"}"
+  name  = "allow-${aws_iam_user.lmcardle.name}-self-manage-mfa"
+  user  = "${aws_iam_user.lmcardle.name}"
+  count = "${terraform.workspace == "prod" ? "1" : "0"}"
 
   policy = <<EOF
 {
@@ -165,7 +165,7 @@ resource "aws_iam_user_login_profile" "lmcardle" {
   user                    = "${aws_iam_user.lmcardle.name}"
   pgp_key                 = "keybase:leomca"
   password_reset_required = false
-	count = "${terraform.workspace == "prod" ? "1" : "0"}"
+  count                   = "${terraform.workspace == "prod" ? "1" : "0"}"
 
   lifecycle {
     ignore_changes = ["password_length", "password_reset_required", "pgp_key"]
@@ -178,21 +178,21 @@ resource "aws_iam_user_login_profile" "lmcardle" {
 
 resource "aws_iam_group_membership" "discourse" {
   name  = "discourse-developers"
-	count = "${terraform.workspace == "prod" ? "1" : "0"}"
+  count = "${terraform.workspace == "prod" ? "1" : "0"}"
   users = ["${aws_iam_user.adelbarrio.name}", "${aws_iam_user.lmcardle.name}"]
   group = "${aws_iam_group.developers.name}"
 }
 
 resource "aws_iam_group" "developers" {
-  name = "developers"
-  path = "/discourse/"
-	count = "${terraform.workspace == "prod" ? "1" : "0"}"
+  name  = "developers"
+  path  = "/discourse/"
+  count = "${terraform.workspace == "prod" ? "1" : "0"}"
 }
 
 resource "aws_iam_group_policy" "discourse-devs" {
   name  = "discourse-developer-policy"
   group = "${aws_iam_group.developers.id}"
-	count = "${terraform.workspace == "prod" ? "1" : "0"}"
+  count = "${terraform.workspace == "prod" ? "1" : "0"}"
 
   policy = <<EOF
 {
@@ -271,7 +271,7 @@ EOF
 resource "aws_iam_group_policy" "self-managed-mfa" {
   name  = "self-managed-mfa"
   group = "${aws_iam_group.developers.id}"
-	count = "${terraform.workspace == "prod" ? "1" : "0"}"
+  count = "${terraform.workspace == "prod" ? "1" : "0"}"
 
   policy = <<EOF
 {
@@ -312,7 +312,7 @@ EOF
 resource "aws_iam_group_policy" "lambda" {
   name  = "discourse-developers-lambda-access"
   group = "${aws_iam_group.developers.id}"
-	count = "${terraform.workspace == "prod" ? "1" : "0"}"
+  count = "${terraform.workspace == "prod" ? "1" : "0"}"
 
   policy = <<EOF
 {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -10,6 +10,10 @@ variable "discourse-url" {
   default = "discourse.mozilla.org"
 }
 
+variable "discourse-cdn-zone" {
+  default = "discourse.mozilla.org"
+}
+
 variable "discourse-elb" {
   default = "fill-me-after-elb-creation"
 }


### PR DESCRIPTION
The most signicative change is the addition of a new parameter for handling a CDN in a different domain that the main domain. We did that because in the middle of the migration realized that the current cdn was in discourse-prod.itsre-apps.cloud, instead of being in cdn.d.m.o. This doesn't have a big impact, but for the sake of cleanliness and to reduce code complexity, we should have always the CDN using the top level domain for each environment. Let's try to get this soon.